### PR TITLE
Prevent Renovate autoupdating VSCode compatibility versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>cucumber/renovate-config",
-    ":automergeMajor"
+    "github>cucumber/renovate-config"
   ],
   "packageRules": [
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,11 @@
   "extends": [
     "github>cucumber/renovate-config",
     ":automergeMajor"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["vscode"],
+      "automerge": false
+    }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@types/glob": "8.1.0",
         "@types/mocha": "10.0.6",
-        "@types/vscode": "1.85.0",
+        "@types/vscode": "1.82.0",
         "@typescript-eslint/eslint-plugin": "6.14.0",
         "@typescript-eslint/parser": "6.14.0",
         "esbuild": "0.19.9",
@@ -1100,9 +1100,9 @@
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "node_modules/@types/vscode": {
-      "version": "1.85.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
-      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -10121,9 +10121,9 @@
       "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA=="
     },
     "@types/vscode": {
-      "version": "1.85.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
-      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.8.0",
   "publisher": "CucumberOpen",
   "engines": {
-    "vscode": "^2023.0.0"
+    "vscode": "^1.82.0"
   },
   "categories": [
     "Programming Languages",
@@ -106,7 +106,7 @@
   "devDependencies": {
     "@types/glob": "8.1.0",
     "@types/mocha": "10.0.6",
-    "@types/vscode": "1.85.0",
+    "@types/vscode": "1.82.0",
     "@typescript-eslint/eslint-plugin": "6.14.0",
     "@typescript-eslint/parser": "6.14.0",
     "esbuild": "0.19.9",


### PR DESCRIPTION
### 🤔 What's changed?

Configures Renovate to prevent automerging changes to the VSCode engine compatibility version - to prevent breaking compatibility; and to restore the version to its correct and previous version.

### ⚡️ What's your motivation? 

Fixes #190.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

`CHANGELOG` has not been updated, as changes were made since the latest release and only affect development builds since. However, please outline if should be updated.

Chose to allow Renovate to continue detecting vscode versions, but to prevent automerge. Alternatively, the VSCode versions could be ignored altogether through the configuration. Please advise whether the latter would be preferential; or whether other changes should be made to configuration.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)