### PR TITLE
Automate validation of `@types/vscode` and `vscode` alignment

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,10 @@
     {
       "matchPackageNames": ["vscode"],
       "automerge": false
+    },
+    {
+      "matchPackageNames": ["@vscode/types"],
+      "enabled": false
     }
   ]
 }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,6 +34,7 @@ jobs:
         cache: 'npm'
         cache-dependency-path: package-lock.json
     - run: npm install-ci-test
+    - run: npm run vscode-types-compatible
     - run: npm run build
     - run: npm run package
     - run: npm run eslint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,9 @@ Achievement unlocked! You are now running the extension locally! 🏆
 
 ## Modifying the Language Server
 
-Once you have completed the [getting started steps](#getting-started), you may be wondering how you can begin modifying the implementation. 🤔
+Once you have completed [getting started](#getting-started), you may be wondering how you can begin modifying the implementation. 🤔
 
-This extension uses the _Language Server Protocol_ to communicate with Visual Studio Code, which is an open protocol that allows a common implementation - called a __language server__ - to communicate with different IDEs. This implementation is stored in the [Cucumber Language Server](https://github.com/cucumber/language-server), and the underlying [Cucumber Language Service](https://github.com/cucumber/language-service). Let's integrate local versions of each into our extension so we can modify them.
+This extension uses the _Language Server Protocol_ to communicate with Visual Studio Code, which is an open protocol that allows the development of a common implementation - called a __language server__ - that can communicate with different IDEs. This implementation is stored in the [Cucumber Language Server](https://github.com/cucumber/language-server) and the underlying [Cucumber Language Service](https://github.com/cucumber/language-service). Let's integrate local versions of each into our extension so we can modify them.
 
 1. First, clone the Language Server and the Language Service to the same directory in which you cloned the extension. Your directory structure should appear as follows:
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ making it easy to navigate between scenarios.
 
 ### Gherkin Localisation
 
-Gherkin supports a multitude of languages. To specify a language, include a `# language: <key>` header in your feature file, replacing `<key>` with the appropriate language key. You can find a list of supported language keys in the [localisation documentation](https://cucumber.io/docs/gherkin/languages/).
+Gherkin supports many translations. To specify a translation, include a `# language: <key>` header in your feature file, replacing `<key>` with a supported language key from the [localisation documentation](https://cucumber.io/docs/gherkin/languages/).
 
 ![Localisation](https://raw.githubusercontent.com/cucumber/vscode/main/images/localisation.png)
 

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "test": "node ./dist/src/test/runTest.js",
     "prepublishOnly": "npm run update-settings-docs",
     "update-settings-docs": "./scripts/update-settings-docs.sh",
+    "vscode-types-compatible": "./scripts/vscode-types-compatible.sh",
     "package": "vsce package",
     "publish": "vsce publish",
     "upgrade": "npm-check-updates --upgrade"

--- a/scripts/vscode-types-compatible.sh
+++ b/scripts/vscode-types-compatible.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script updates the docs for the configuration properties.
+# It extracts sections from the README.md and writes them into the markdownDescription
+# fields in `package.json`.
+
+# Parse package.json and get the versions of the two packages
+vscodeVersion=$(jq -r '.engines.vscode' package.json)
+vscodeSemanticVersion=$(echo $vscodeVersion | sed 's/\^//g')
+vscodeTypesVersion=$(jq -r '.devDependencies["@types/vscode"]' package.json)
+
+# Compare the versions
+if [ "$vscodeTypesVersion" != "$vscodeSemanticVersion" ]; then
+  echo "The @types/vscode package version ($vscodeTypesVersion) does not match the VSCode compatibility engine version ($vscodeSemanticVersion). Please update @types/vscode to match."
+  exit 1
+else
+  echo "The @types/vscode package version ($vscodeTypesVersion) matches the VSCode compatibility engine version ($vscodeSemanticVersion)."
+  exit 0
+fi


### PR DESCRIPTION
### 🤔 What's changed?

- Prevent Renovate PRs for `@types/vscode`
- Added script in workflow to validate the `@types/vscode` is below the `vscode` compatibility engine version

### ⚡️ What's your motivation? 

- Reduce noise - prevent non-actionable PRs from Renovate
- Prevent merging updates to the `vscode` compatibility engine without updating `@types/vscode` - as the pipeline will fail
  - This will prevent the development environment entering an unrunnable state (#190)

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)