### PR TITLE
Simplify GitHub release

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -13,15 +13,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - run: npm install-ci-test
-      - name: Show Dependency Manifest
-        run: npm ls -a
-      - run: npm run build
-      - run: npm run package
-      - name: GitHub Release
-        uses: softprops/action-gh-release@v1
+      - uses: cucumber/action-create-github-release@v1.1.1
         with:
-          tag_name: ${{ github.ref_name }}
-          files: |
-            *.vsix
-            LICENSE
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### 🤔 What's changed?

Replaced the GitHub Release action with one used in the whole Cucumber organization. This does remove publishing of the packaged resource to Github.

### ⚡️ What's your motivation? 

Currently, the release workflow releases to the Open VSX Registry and Visual Studio Marketplace. I don't think we also have to publish a packed file to GitHub.

This allows the Release GitHub Action to be identical to the action in all other Cucumber repositories.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

I'm not 100% sure what the common distribution channels are. I would assume that people generally use the public registry.

