### PR TITLE
Default semantic highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Cucumber icon for feature files ([#206](https://github.com/cucumber/vscode/pull/206))
+- Semantic highlighting enabled by default for gherkin ([#207](https://github.com/cucumber/vscode/pull/207))
 
 ## [1.8.1] - 2024-01-14
 ### Changed

--- a/package.json
+++ b/package.json
@@ -41,6 +41,11 @@
         }
       }
     ],
+    "configurationDefaults": {
+      "[cucumber]": {
+        "editor.semanticHighlighting.enabled": true
+      }
+    },
     "configuration": {
       "title": "Cucumber",
       "properties": {


### PR DESCRIPTION
### 🤔 What's changed?

Overrided semantic highlighting configuration to be enabled with gherkin by default.

### ⚡️ What's your motivation? 

Relates to #89.

Gherkin syntax highlighting depends upon semantic highlighting. This is not enabled by all themes by default.

This results in an initial user experience where depending on the user's colour theme and settings, syntax highlighting may not work completely as expected. This can be considered a "bug".

Overriding semantic highlighting configuration to be enabled for gherkin, will result in a better user experience and improved syntax highlighting support.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

Whether resolves issue for 'GitHub Dark' and 'GitHub' light themes.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.