### PR TITLE
Validate README and package.json settings alignment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
         cache-dependency-path: package-lock.json
     - run: npm install-ci-test
     - run: npm run vscode-types-compatible
+    - run: npm run update-settings-docs
     - run: npm run build
     - run: npm run package
     - run: npm run eslint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+npx lint-staged --no-stash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,13 +88,13 @@ If your changes are not reflected or something went wrong, we would love to know
 
 Before submitting a pull request, there are a few actions that we must ensure to carry out.
 
-- Format all code to align with project coding standards.
+- Format all code to align with project coding standards. This is executed by the pre-commit hook by default.
 
     ```console
     npm run eslint-fix
     ```
 
-- Run the update command for any modifications to [extension settings](README.md#extension-settings) in `README.md`, to ensure they are reflected in `package.json`.
+- Run the update command for any modifications to [extension settings](README.md#extension-settings) in `README.md`, to ensure they are reflected in `package.json`. This is executed by the pre-commit hook by default.
 
     ```console
     npm run update-settings-docs

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ New translations or updates are welcome and can be submitted through the [gherki
 
 Support is provided for step definitions from [different languages and frameworks](#features).
 
-If your language or framework is unsupported, please [open an issue](https://github.com/cucumber/language-service/issues) or [raise a pull request](https://github.com/cucumber/language-service/pulls) in the [Cucumber Language Service](https://github.com/cucumber/language-service) - where language support is implemented.
+If you experience an issue with a supported language, please [raise a detailed bug report](https://github.com/cucumber/vscode/issues) or reach out for help through [our Slack community](https://cucumber.io/community#slack).
 
-If you experience any issues using the extension with a supported language, please [raise a bug report](https://github.com/cucumber/vscode/issues) with as much detail as possible or reach out for help through [our Slack community](https://cucumber.io/community#slack).
+If your language or framework is unsupported, please [open an issue](https://github.com/cucumber/language-service/issues) or [raise a pull request](https://github.com/cucumber/language-service/pulls) in the [Cucumber Language Service](https://github.com/cucumber/language-service) - where language support is implemented.
 
 ## Extension Settings
 

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "upgrade": "npm-check-updates --upgrade"
   },
   "lint-staged": {
+    "README.md": "npm run update-settings-docs",
     "src/**/*.ts": "npm run eslint-fix"
   },
   "dependencies": {

--- a/scripts/vscode-types-compatible.sh
+++ b/scripts/vscode-types-compatible.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# This script updates the docs for the configuration properties.
-# It extracts sections from the README.md and writes them into the markdownDescription
-# fields in `package.json`.
+# This script validates whether the @types/vscode package version matches the VSCode
+# compatibility engine version. If the types exceeds the engine version, then the
+# extension will not run.
 
 # Parse package.json and get the versions of the two packages
 vscodeVersion=$(jq -r '.engines.vscode' package.json)


### PR DESCRIPTION
### 🤔 What's changed?

Validate settings alignment between README.md and package.json in pipeline and pre-commit.

### ⚡️ What's your motivation? 

Extension settings must be specified in package.json for VSCode, and additionally in the README for documentation purposes. This leads to two sources for the same information.

Although a script exists to update associated README changes in package.json, there is no validation in the pipeline or pre-commit that this has been applied; which has previously resulted in the two files going out of sync.

Codifying these rules removes the need for implicit knowledge for maintaining and contributing to the project; and removes the need to check that these rules have been applied during code review.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)