### PR TITLE
Optimise default glue paths in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,18 +178,8 @@ Default value:
 {
   "cucumber.glue": [
     "*specs*/**/*.cs",
-    "features/**/*.js",
-    "features/**/*.jsx",
-    "features/**/*.php",
-    "features/**/*.py",
-    "features/**/*.rs",
-    "features/**/*.rb",
-    "features/**/*.ts",
-    "features/**/*.tsx",
-    "features/**/*_test.go",
-    "src/test/**/*.java",
-    "tests/**/*.py",
-    "tests/**/*.rs"
+    "features/**/*{.js,.jsx,.php,.py,.rb,.rs,.ts,.tsx,_test.go,.java}",
+    "tests/**/*{.py,.rs}"
   ]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -61,23 +61,13 @@
           ]
         },
         "cucumber.glue": {
-          "markdownDescription": "The `cucumber.glue` setting overrides where the extension\nshould look for source code where step definitions and\nparameter types are defined.\n\nIf no glue files are found, [autocomplete](#autocomplete)\nwill not work, and all Gherkin steps will be underlined as\nundefined. [Generate step definition](#generate-step-definition)\nwill not work either.\n\nDefault value:\n\n```json\n{\n  \"cucumber.glue\": [\n    \"*specs*/**/*.cs\",\n    \"features/**/*.js\",\n    \"features/**/*.jsx\",\n    \"features/**/*.php\",\n    \"features/**/*.py\",\n    \"features/**/*.rs\",\n    \"features/**/*.rb\",\n    \"features/**/*.ts\",\n    \"features/**/*.tsx\",\n    \"features/**/*_test.go\",\n    \"src/test/**/*.java\",\n    \"tests/**/*.py\",\n    \"tests/**/*.rs\"\n  ]\n}\n```",
+          "markdownDescription": "The `cucumber.glue` setting overrides where the extension\nshould look for source code where step definitions and\nparameter types are defined.\n\nIf no glue files are found, [autocomplete](#autocomplete)\nwill not work, and all Gherkin steps will be underlined as\nundefined. [Generate step definition](#generate-step-definition)\nwill not work either.\n\nDefault value:\n\n```json\n{\n  \"cucumber.glue\": [\n    \"*specs*/**/*.cs\",\n    \"features/**/*{.js,.jsx,.php,.py,.rb,.rs,.ts,.tsx,_test.go,.java}\",\n    \"tests/**/*{.py,.rs}\"\n  ]\n}\n```",
           "type": "array",
           "required": false,
           "default": [
             "*specs*/**/*.cs",
-            "features/**/*.js",
-            "features/**/*.jsx",
-            "features/**/*.php",
-            "features/**/*.py",
-            "features/**/*.rs",
-            "features/**/*.rb",
-            "features/**/*.ts",
-            "features/**/*.tsx",
-            "features/**/*_test.go",
-            "src/test/**/*.java",
-            "tests/**/*.py",
-            "tests/**/*.rs"
+            "features/**/*{.js,.jsx,.php,.py,.rb,.rs,.ts,.tsx,_test.go,.java}",
+            "tests/**/*{.py,.rs}"
           ]
         },
         "cucumber.parameterTypes": {


### PR DESCRIPTION
### 🤔 What's changed?

- Optimised default glue paths to merge repeated patterns to improve performance

### ⚡️ What's your motivation? 

- As the extension performs a complete reindex on code changes for specified glob paths, it is important that these paths are optimal for best performance
- Code volume is reduced considerably, making it clearer which file extensions are expected under common paths

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
- [ ] Complete benchmark of the changes