### PR TITLE
feat: add TextMate grammar

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,4 +9,5 @@
 !images/icon.png
 !images/icon.svg
 !out/*.js
+!out/*.json
 !out/*.wasm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- TextMate grammar rules ([#332](https://github.com/cucumber/vscode/pull/332))
 
 ## [1.11.0] - 2025-05-18
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,7 @@ The following resources are useful in the development of this extension.
 - [Visual Studio Code Extension documentation](https://code.visualstudio.com/api) - Comprehensive documentation covering capabilities, guides and guidelines for Visual Studio Code extensions.
 - [Contributing Guidelines for the Cucumber Language Service](https://github.com/cucumber/language-service/blob/main/CONTRIBUTING.md) - Guidance for contributing to the [Cucumber Language Service](https://github.com/cucumber/language-service), the core component responsible for implementing the majority of features in this extension.
 - Type definitions for the Visual Studio Code Extension API release used by this extension can be found within the file `node_modules/@types/vscode/index.d.ts`.
+- [TextMate Language Grammars documentation](https://macromates.com/manual/en/language_grammars) - Guidance for when modifying `cucumber.tmLanguage.json` (and `scripts/update-grammar.js`).
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ to add it to.
 ![Syntax highlighting](https://raw.githubusercontent.com/cucumber/vscode/main/images/syntax-highlighting.gif)
 
 Gherkin keywords and step parameters are highlighted.
+All other text is classified using TextMate tokens (styled by VSCode color themes).
 Undefined steps and syntax errors are underlined.
 
 ### Formatting

--- a/cucumber.tmLanguage.json
+++ b/cucumber.tmLanguage.json
@@ -1,0 +1,146 @@
+{
+  "scopeName": "source.cucumber",
+  "fileTypes": ["feature"],
+  "patterns": [
+    {
+      "name": "meta.feature.cucumber",
+      "begin": "^\\s*(Feature)(:)(.*)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.section.feature.cucumber" },
+        "2": { "name": "punctuation.separator.cucumber" },
+        "3": { "name": "string.unquoted.feature.cucumber" }
+      },
+      "end": "$"
+    },
+    {
+      "name": "meta.rule.cucumber",
+      "begin": "^\\s*(Rule)(:)(.*)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.section.rule.cucumber" },
+        "2": { "name": "punctuation.separator.cucumber" },
+        "3": { "name": "string.unquoted.rule.cucumber" }
+      },
+      "end": "$"
+    },
+    {
+      "name": "meta.background.cucumber",
+      "begin": "^\\s*(Background)(:)(.*)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.background.cucumber" },
+        "2": { "name": "punctuation.separator.cucumber" },
+        "3": { "name": "string.unquoted.background.cucumber" }
+      },
+      "end": "$"
+    },
+    {
+      "name": "meta.scenario.cucumber",
+      "begin": "^\\s*(Scenario(?: Outline| Template)?|Example)(:)(.*)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.section.scenario.cucumber" },
+        "2": { "name": "punctuation.separator.cucumber" },
+        "3": { "name": "string.unquoted.scenario.cucumber" }
+      },
+      "end": "$"
+    },
+    {
+      "name": "meta.step.cucumber",
+      "begin": "^\\s*(Given|When|Then|And|But|\\*) ",
+      "beginCaptures": {
+        "1": { "name": "keyword.other.step.cucumber" }
+      },
+      "patterns": [
+        {
+          "match": "(<)([^>]*)(>)",
+          "captures": {
+            "1": { "name": "punctuation.definition.variable.cucumber" },
+            "2": { "name": "variable.other.cucumber" },
+            "3": { "name": "punctuation.definition.variable.cucumber" }
+          }
+        },
+        {
+          "match": "[^<>]+",
+          "name": "string.unquoted.step.cucumber"
+        }
+      ],
+      "end": "$"
+    },
+    {
+      "name": "meta.examples.cucumber",
+      "begin": "^\\s*(Examples|Scenarios)(:)(.*)",
+      "beginCaptures": {
+        "1": { "name": "keyword.control.examples.cucumber" },
+        "2": { "name": "punctuation.separator.cucumber" },
+        "3": { "name": "string.unquoted.examples.cucumber" }
+      },
+      "end": "$"
+    },
+    {
+      "name": "meta.doc-string.cucumber",
+      "begin": "^\\s*(\"\"\"|```)\\s*$",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.doc-string.cucumber" }
+      },
+      "contentName": "string.quoted.doc-string.cucumber",
+      "end": "^\\s*(\"\"\"|```)",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.doc-string.cucumber" }
+      }
+    },
+    {
+      "name": "meta.doc-string.cucumber",
+      "begin": "^\\s*(\"\"\"|```)(\\w+)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.doc-string.cucumber" },
+        "2": { "name": "fenced_code.block.language.cucumber" }
+      },
+      "contentName": "meta.embedded.block.$2",
+      "patterns": [
+        { "include": "source.json" },
+        { "include": "source.markdown" },
+        { "include": "source.xml" },
+        { "include": "source.yaml" }
+      ],
+      "end": "^\\s*(\"\"\"|```)",
+      "endCaptures": {
+        "1": { "name": "punctuation.definition.doc-string.cucumber" }
+      }
+    },
+    {
+      "name": "meta.table.cucumber",
+      "begin": "^\\s*(?=\\|)",
+      "patterns": [
+        {
+          "match": "\\|",
+          "name": "punctuation.definition.table.cucumber"
+        },
+        {
+          "match": "[^|\\n]+",
+          "name": "string.unquoted.table.cucumber"
+        }
+      ],
+      "end": "$"
+    },
+    {
+      "name": "meta.tags.cucumber",
+      "begin": "\\s*(@)(\\w*)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.tag.cucumber" },
+        "2": { "name": "entity.name.tag.cucumber" }
+      },
+      "end": "\\s"
+    },
+    {
+      "name": "meta.comment.cucumber",
+      "begin": "^\\s*(#)(.*)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.definition.comment.cucumber" },
+        "2": { "name": "comment.line.number-sign.cucumber" }
+      },
+      "end": "$"
+    },
+    {
+      "match": ".*",
+      "name": "comment.block.cucumber"
+    }
+  ]
+}

--- a/cucumber.tmLanguage.json
+++ b/cucumber.tmLanguage.json
@@ -76,7 +76,7 @@
     },
     {
       "name": "meta.doc-string.cucumber",
-      "begin": "^\\s*(\"\"\"|```)\\s*$",
+      "begin": "^\\s*(\"\"\"|```)$",
       "beginCaptures": {
         "1": { "name": "punctuation.definition.doc-string.cucumber" }
       },

--- a/package.json
+++ b/package.json
@@ -41,6 +41,20 @@
         }
       }
     ],
+    "grammars": [
+      {
+        "language": "cucumber",
+        "scopeName": "source.cucumber",
+        "path": "./out/cucumber.tmLanguage.json",
+        "embeddedLanguages": {
+          "meta.embedded.block.json": "json",
+          "meta.embedded.block.markdown": "markdown",
+          "meta.embedded.block.md": "markdown",
+          "meta.embedded.block.xml": "xml",
+          "meta.embedded.block.yaml": "yaml"
+        }
+      }
+    ],
     "configurationDefaults": {
       "[cucumber]": {
         "editor.semanticHighlighting.enabled": true
@@ -92,7 +106,8 @@
   "scripts": {
     "vscode:prepublish": "npm run build",
     "esbuild-extension": "esbuild ./src/extension.ts --external:vscode --bundle --outfile=out/extension.js --format=cjs --platform=node --minify --sourcemap",
-    "build": "npm run esbuild-extension",
+    "update-grammar": "node ./scripts/update-grammar.js",
+    "build": "npm run esbuild-extension && npm run update-grammar",
     "compile": "tsc --build",
     "prepare": "husky && npm run copy-wasms",
     "copy-wasms": "mkdir -p out && cp node_modules/@cucumber/language-service/dist/*.wasm out",

--- a/scripts/update-grammar.js
+++ b/scripts/update-grammar.js
@@ -18,7 +18,7 @@ function getLanguageKeywords(languages) {
     examples: new Set(),
   }
   for (const lang in languages) {
-    const data = lang[language]
+    const data = languages[lang]
     data.feature.forEach((k) => keywords.feature.add(k.trim()))
     data.rule.forEach((k) => keywords.rule.add(k.trim()))
     data.background.forEach((k) => keywords.background.add(k.trim()))

--- a/scripts/update-grammar.js
+++ b/scripts/update-grammar.js
@@ -1,0 +1,63 @@
+/**
+ * This script copies the keywords from all Gherkin languages into `cucumber.tmLanguage.json`'s regular expressions, saving the modified copy to `out/cucumber.tmLanguage.json` for use by the VSCode extension.
+ */
+const fs = require('fs')
+const path = require('path')
+
+const languages = JSON.parse(
+  fs.readFileSync('node_modules/@cucumber/gherkin/src/gherkin-languages.json', 'utf8')
+)
+
+function getLanguageKeywords(languages) {
+  const keywords = {
+    feature: new Set(),
+    rule: new Set(),
+    background: new Set(),
+    scenario: new Set(),
+    step: new Set(),
+    examples: new Set(),
+  }
+  for (const lang in languages) {
+    const data = lang[language]
+    data.feature.forEach((k) => keywords.feature.add(k.trim()))
+    data.rule.forEach((k) => keywords.rule.add(k.trim()))
+    data.background.forEach((k) => keywords.background.add(k.trim()))
+    data.scenario.forEach((k) => keywords.scenario.add(k.trim()))
+    data.scenarioOutline.forEach((k) => keywords.scenario.add(k.trim()))
+    data.given.forEach((k) => keywords.step.add(k.trim()))
+    data.when.forEach((k) => keywords.step.add(k.trim()))
+    data.then.forEach((k) => keywords.step.add(k.trim()))
+    data.and.forEach((k) => keywords.step.add(k.trim()))
+    data.but.forEach((k) => keywords.step.add(k.trim()))
+    data.examples.forEach((k) => keywords.examples.add(k.trim()))
+  }
+  function doubleEscape(s) {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+  return Object.fromEntries(
+    Object.entries(keywords).map(([k, set]) => [k, Array.from(set).map(doubleEscape).join('|')])
+  )
+}
+
+const keywords = getLanguageKeywords(languages)
+const tmLanguage = JSON.parse(fs.readFileSync('cucumber.tmLanguage.json', 'utf8'))
+tmLanguage.patterns.forEach((p) => {
+  if (p.name === 'meta.feature.cucumber') {
+    p.begin = p.begin.replace('Feature', keywords.feature)
+  } else if (p.name === 'meta.rule.cucumber') {
+    p.begin = p.begin.replace('Rule', keywords.rule)
+  } else if (p.name === 'meta.background.cucumber') {
+    p.begin = p.begin.replace('Background', keywords.background)
+  } else if (p.name === 'meta.scenario.cucumber') {
+    p.begin = p.begin.replace('Scenario(?: Outline| Template)?|Example', keywords.scenario)
+  } else if (p.name === 'meta.step.cucumber') {
+    p.begin = p.begin.replace('Given|When|Then|And|But', keywords.step)
+  } else if (p.name === 'meta.examples.cucumber') {
+    p.begin = p.begin.replace('Examples|Scenarios', keywords.examples)
+  }
+})
+const outPath = 'out/cucumber.tmLanguage.json'
+if (!fs.existsSync(path.dirname(outPath))) {
+  fs.mkdirSync(path.dirname(outPath), { recursive: true })
+}
+fs.writeFileSync(outPath, JSON.stringify(tmLanguage))


### PR DESCRIPTION
### 🤔 What's changed?

- Added `cucumber.tmLanguage.json` which contains TextMate grammar rules for enhanced syntax highlighting and colour theme customisation.
- Added `scripts/update-grammar.js` which updates `cucumber.tmLanguage.json` with all Gherkin language keywords and saves it to `out/cucumber.tmLanguage.json` (which is whitelisted in `.vscodeignore`).
- Changed `package.json`'s scripts to add `update-grammar`, which is run during `npm run build`, and to include the new TextMate grammar rules, as well as the embedded languages `json`, `xml`, `yaml` (VSCode in-built data serialisation languages) and `markdown` (commonly used to store large text).
- **Documentation updates**
  - `README.md` updated
  - [TextMate Language Grammars documentation](https://macromates.com/manual/en/language_grammars) added to `CONTRIBUTING.md`

### ⚡️ What's your motivation? 

The semantic highlighting that this VSCode extension currently supplies is insufficient when it comes to understanding feature files at a glance, as a lot of colour and font style customisations that could be applied to these files (e.g., heading styles, block comments, etc.) is absent. The most egregious example of this is feature, rule and scenario descriptions not standing out from step names.

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

Example below (colour theme is 'Dark 2026'):

<img width="500" alt="Screenshot of TextMate token colours" src="https://github.com/user-attachments/assets/f9d9f17f-03d5-4612-b844-f6fd470f5adf" />

### ♻️ Anything particular you want feedback on?

- The semantic highlighting this plugin already provides overrides the TextMate grammar rules, meaning colour customisations for tags and keywords are completely replaced while semantic highlighting is active, making it harder to control their underlying styles. I'd like to suggest that only variable values be covered by semantic highlighting, as they cannot be ascertained by TextMate grammar rules alone.
- There may be edge cases with my regular expressions that I have failed to cover.
- I wasn't able to figure out how to give only the first row of table cells a token that defines them as variable names. Then again, this may not be necessary depending on how the majority of testers use data tables.
- I have chosen TextMate token names according to [Language Grammars Naming Conventions](https://macromates.com/manual/en/language_grammars), though these token names are still only my choices. I wouldn't mind suggestions for what the token names should be, as once they are committed into the main branch, it is unlikely they will be changed again.
- Currently, only `json`, `markdown`, `xml` and `yaml` are supported as embedded languages in doc strings. This list may need to be expanded depending on the needs of testers. It would be very difficult to dynamically update this list.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] ~~I have added/updated tests to cover my changes.~~ (This VSCode plugin has no automated tests to assess its functionality. I tested my changes through manual testing.)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.